### PR TITLE
71: return html node instead of html as text by side kick helper, to …

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -50,12 +50,12 @@ Parameters:
 
 Examples:
 
-const button = extractSidekickLibraryId(document.querySelector('a'));
+const cta = extractSidekickLibraryId(document.querySelector('a'));
 <a
- href="${button.href}"
- data-library-id="${ifDefined(button.id)}"
- contenteditable="${ifDefined(button.id ? true : undefined)}">
-   ${button.text}
+ href="${cta.href}"
+ data-library-id="${ifDefined(cta.dataLibraryId)}"
+ contenteditable="${ifDefined(cta.dataLibraryId ? true : undefined)}">
+   ${cta.content}
 </a>
 
 
@@ -115,7 +115,7 @@ Represents the constructed Element.
 | ---------- | ---------- |
 | `SidekickElement` | `{
   dataLibraryId?: string;
-  innerHTML: string;
+  content: string;
   href?: string;
 }` |
 

--- a/src/directives/sidekickLibraryId.ts
+++ b/src/directives/sidekickLibraryId.ts
@@ -1,6 +1,6 @@
 import { Directive, directive } from 'lit/directive.js';
 import { AttributePart, nothing } from 'lit';
-import { SidekickElement } from 'Helpers/sidekick/extractSidekickLibraryId';
+import type { SidekickElement } from 'Helpers/sidekick/extractSidekickLibraryId';
 import { isSidekickLibraryActive } from 'Helpers/sidekick//isSidekickLibraryActive';
 
 /**

--- a/src/helpers/sidekick/extractSidekickLibraryId.spec.ts
+++ b/src/helpers/sidekick/extractSidekickLibraryId.spec.ts
@@ -7,7 +7,7 @@ describe('extractSidekickLibraryId', () => {
   beforeEach(() => {
     expected = {
       dataLibraryId: undefined,
-      innerHTML: '',
+      content: new DocumentFragment(),
       href: '',
     };
   });
@@ -17,15 +17,16 @@ describe('extractSidekickLibraryId', () => {
     expect(result).toEqual(expected);
   });
 
-  test('extracts innerHTML correctly', () => {
+  test('extracts content correctly', () => {
     const element = document.createElement('div');
     const innerHTML = '<p>Hello, World!</p>';
 
     element.innerHTML = innerHTML;
-    expected.innerHTML = innerHTML;
 
     const result = extractSidekickLibraryId(element);
-    expect(result).toEqual(expected);
+    const target = document.createElement('div');
+    target.append(result.content);
+    expect(target.innerHTML).toEqual(innerHTML);
   });
 
   test('extracts href attribute correctly for anchor elements', () => {

--- a/src/helpers/sidekick/extractSidekickLibraryId.ts
+++ b/src/helpers/sidekick/extractSidekickLibraryId.ts
@@ -10,7 +10,7 @@ import { isSidekickLibraryActive } from './isSidekickLibraryActive.ts';
  */
 export type SidekickElement = {
   dataLibraryId?: string;
-  innerHTML: string;
+  content: DocumentFragment;
   href?: string;
 };
 
@@ -22,12 +22,12 @@ export type SidekickElement = {
  * @returns {SidekickElement} - A constructed element object.
  *
  * @example
- * const button = extractSidekickLibraryId(document.querySelector('a'));
+ * const cta = extractSidekickLibraryId(document.querySelector('a'));
  * <a
- *  href="${button.href}"
- *  data-library-id="${ifDefined(button.id)}"
- *  contenteditable="${ifDefined(button.id ? true : undefined)}">
- *    ${button.text}
+ *  href="${cta.href}"
+ *  data-library-id="${ifDefined(cta.dataLibraryId)}"
+ *  contenteditable="${ifDefined(cta.dataLibraryId ? true : undefined)}">
+ *    ${cta.content}
  * </a>
  *
  * @remarks
@@ -37,12 +37,12 @@ export type SidekickElement = {
 export const extractSidekickLibraryId = (element?: HTMLElement | HTMLAnchorElement | null): SidekickElement => {
   const constructedElement: SidekickElement = {
     dataLibraryId: undefined,
-    innerHTML: '',
+    content: new DocumentFragment(),
     href: '',
   };
   if (!element) return constructedElement;
 
-  constructedElement.innerHTML = element.innerHTML;
+  constructedElement.content.append(...element.cloneNode(true).childNodes);
   if (element instanceof HTMLAnchorElement && element.href !== '') {
     constructedElement.href = element.href;
   }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/ifahrentholz/eds-editorial/issues/71

Test URLs:

- Before: https://develop--eds-boilerplate--diva-e.hlx.page/
- After:  https://71-fix-sidekick-helper-render--eds-boilerplate--diva-e.hlx.page/
